### PR TITLE
Add cancellable operations

### DIFF
--- a/lib/xqlite/xqlitenif.ex
+++ b/lib/xqlite/xqlitenif.ex
@@ -24,6 +24,8 @@ defmodule XqliteNIF do
   def schema_index_columns(_conn, _index_name), do: err()
   def get_create_sql(_conn, _object_name), do: err()
   def last_insert_rowid(_conn), do: err()
+  def create_cancel_token(), do: err()
+  def cancel_operation(_token_resource), do: err()
 
   defp err, do: :erlang.nif_error(:nif_not_loaded)
 end

--- a/native/xqlitenif/src/cancel.rs
+++ b/native/xqlitenif/src/cancel.rs
@@ -1,0 +1,25 @@
+use rustler::{resource_impl, Resource};
+use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub(crate) struct XqliteCancelToken(pub(crate) Arc<AtomicBool>);
+
+#[resource_impl]
+impl Resource for XqliteCancelToken {}
+
+impl XqliteCancelToken {
+    pub(crate) fn new() -> Self {
+        XqliteCancelToken(Arc::new(AtomicBool::new(false)))
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.0.store(true, Ordering::Release); // Use Release for store
+    }
+
+    // #[allow(dead_code)] // Mark as allowed since it's not used in this immediate step
+    pub(crate) fn is_cancelled(&self) -> bool {
+        self.0.load(Ordering::Relaxed) // Use Relaxed for load (Acquire also fine if store is Release)
+    }
+}

--- a/native/xqlitenif/src/lib.rs
+++ b/native/xqlitenif/src/lib.rs
@@ -100,6 +100,7 @@ rustler::atoms! {
     view
 }
 
+mod cancel;
 mod error;
 mod nif;
 mod schema;


### PR DESCRIPTION
We want any longer-running operation be cancellable from another Elixir process -- provided it's still in progress by the time the cancel is requested. Goal: the Elixir process that's currently busy should have their function call -- one of the `*_cancellable` functions -- return `{:error, :operation_cancelled}`.

### Task list
- [x] Add cancel token.
- [ ] Add `query_cancellable` function.
- [ ] Add `execute_cancellable` function.
- [ ] Add `execute_batch_cancellable` function.
- [ ] Add generic `cancel_operation` that can be used to cancel any of the above operations if they are still in progress, and will need an extra function argument, namely the cancel token itself.