### PR TITLE
Cleanup before first release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable # Or actions-rs/toolchain@v1
         with:
           toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
 
       - name: Restore Elixir dependencies cache
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -33,20 +33,17 @@ The library provides two primary modules: `Xqlite` for a higher-level Elixir API
 ### Low-level NIF API (`XqliteNIF` module)
 
 - **Connection Management:**
-
   - `open(path :: String.t())`: Opens a file-based database.
-  - `open_in_memory(uri :: String.t() \\ ":memory:")`: Opens an in-memory database.
+  - `open_in_memory()` or `open_in_memory(uri :: String.t())`: Opens an in-memory database.
   - `open_temporary()`: Opens a private, temporary on-disk database.
-  - `close(conn)`: Conceptually closes the connection. Returns `:ok` on success.
+  - `close(conn)`: Closes the connection.
 
 - **Query Execution:**
-
   - `query(conn, sql :: String.t(), params :: list() | keyword())`: Executes `SELECT` or other row-returning statements.
   - `query_cancellable(conn, sql :: String.t(), params :: list() | keyword(), cancel_token)`: Cancellable version.
     - Returns `{:ok, %{columns: [String.t()], rows: [[term()]], num_rows: non_neg_integer()}}` or `{:error, reason}`.
 
 - **Statement Execution:**
-
   - `execute(conn, sql :: String.t(), params :: list())`: Executes non-row-returning statements (e.g., `INSERT`, `UPDATE`, `DDL`).
   - `execute_cancellable(conn, sql :: String.t(), params :: list(), cancel_token)`: Cancellable version.
   - `execute_batch(conn, sql_batch :: String.t())`: Executes multiple SQL statements. Returns `:ok` on success.
@@ -55,34 +52,28 @@ The library provides two primary modules: `Xqlite` for a higher-level Elixir API
     - `execute_batch` variants return `:ok` on success or `{:error, reason}`.
 
 - **Streaming Primitives:**
-
   - `stream_open(conn, sql, params, opts)`: Prepares a query and returns a stream handle.
   - `stream_get_columns(stream_handle)`: Retrieves column names from the prepared stream.
   - `stream_fetch(stream_handle, batch_size)`: Fetches a batch of rows from the stream.
   - `stream_close(stream_handle)`: Closes the stream and finalizes the statement.
 
 - **Operation Cancellation:**
-
   - `create_cancel_token()`: Creates a token for signalling cancellation. Returns `{:ok, token_resource}`.
   - `cancel_operation(cancel_token)`: Signals an operation associated with the token to cancel. Returns `:ok` on success.
 
 - **PRAGMA Handling:**
-
   - `get_pragma(conn, pragma_name :: String.t())`: Reads a PRAGMA value.
   - `set_pragma(conn, pragma_name :: String.t(), value :: term())`: Sets a PRAGMA value. Returns `:ok` on success.
 
 - **Transaction Control:**
-
   - `begin(conn)`, `commit(conn)`, `rollback(conn)`
   - `savepoint(conn, name)`, `release_savepoint(conn, name)`, `rollback_to_savepoint(conn, name)`
   - All return `:ok` on success or `{:error, reason}`.
 
 - **Inserted Row ID:**
-
   - `last_insert_rowid(conn)`: Retrieves the `rowid` of the most recent `INSERT`.
 
 - **Schema Introspection:**
-
   - `schema_databases(conn)`
   - `schema_list_objects(conn, schema \\ nil)` (Returns `Xqlite.Schema.SchemaObjectInfo` with `:is_without_rowid` flag)
   - `schema_columns(conn, table_name)` (Returns `Xqlite.Schema.ColumnInfo` with `:hidden_kind` flag)

--- a/README.md
+++ b/README.md
@@ -32,18 +32,18 @@ The library provides two primary modules: `Xqlite` for a higher-level Elixir API
 
 ### Low-level NIF API (`XqliteNIF` module)
 
-- **Connection Management:**
+- **Connection management:**
   - `open(path :: String.t())`: Opens a file-based database.
   - `open_in_memory()` or `open_in_memory(uri :: String.t())`: Opens an in-memory database.
   - `open_temporary()`: Opens a private, temporary on-disk database.
   - `close(conn)`: Closes the connection.
 
-- **Query Execution:**
+- **Query execution:**
   - `query(conn, sql :: String.t(), params :: list() | keyword())`: Executes `SELECT` or other row-returning statements.
   - `query_cancellable(conn, sql :: String.t(), params :: list() | keyword(), cancel_token)`: Cancellable version.
     - Returns `{:ok, %{columns: [String.t()], rows: [[term()]], num_rows: non_neg_integer()}}` or `{:error, reason}`.
 
-- **Statement Execution:**
+- **Statement execution:**
   - `execute(conn, sql :: String.t(), params :: list())`: Executes non-row-returning statements (e.g., `INSERT`, `UPDATE`, `DDL`).
   - `execute_cancellable(conn, sql :: String.t(), params :: list(), cancel_token)`: Cancellable version.
   - `execute_batch(conn, sql_batch :: String.t())`: Executes multiple SQL statements. Returns `:ok` on success.
@@ -51,29 +51,29 @@ The library provides two primary modules: `Xqlite` for a higher-level Elixir API
     - `execute` variants return `{:ok, affected_rows :: non_neg_integer()}`.
     - `execute_batch` variants return `:ok` on success or `{:error, reason}`.
 
-- **Streaming Primitives:**
+- **Streaming primitives:**
   - `stream_open(conn, sql, params, opts)`: Prepares a query and returns a stream handle.
   - `stream_get_columns(stream_handle)`: Retrieves column names from the prepared stream.
   - `stream_fetch(stream_handle, batch_size)`: Fetches a batch of rows from the stream.
   - `stream_close(stream_handle)`: Closes the stream and finalizes the statement.
 
-- **Operation Cancellation:**
+- **Operation cancellation:**
   - `create_cancel_token()`: Creates a token for signalling cancellation. Returns `{:ok, token_resource}`.
   - `cancel_operation(cancel_token)`: Signals an operation associated with the token to cancel. Returns `:ok` on success.
 
-- **PRAGMA Handling:**
+- **PRAGMA handling:**
   - `get_pragma(conn, pragma_name :: String.t())`: Reads a PRAGMA value.
   - `set_pragma(conn, pragma_name :: String.t(), value :: term())`: Sets a PRAGMA value. Returns `:ok` on success.
 
-- **Transaction Control:**
+- **Transaction control:**
   - `begin(conn)`, `commit(conn)`, `rollback(conn)`
   - `savepoint(conn, name)`, `release_savepoint(conn, name)`, `rollback_to_savepoint(conn, name)`
   - All return `:ok` on success or `{:error, reason}`.
 
-- **Inserted Row ID:**
+- **Inserted row ID:**
   - `last_insert_rowid(conn)`: Retrieves the `rowid` of the most recent `INSERT`.
 
-- **Schema Introspection:**
+- **Schema introspection:**
   - `schema_databases(conn)`
   - `schema_list_objects(conn, schema \\ nil)` (Returns `Xqlite.Schema.SchemaObjectInfo` with `:is_without_rowid` flag)
   - `schema_columns(conn, table_name)` (Returns `Xqlite.Schema.ColumnInfo` with `:hidden_kind` flag)
@@ -82,7 +82,7 @@ The library provides two primary modules: `Xqlite` for a higher-level Elixir API
   - `schema_index_columns(conn, index_name)`
   - `get_create_sql(conn, object_name)`
 
-- **Error Handling:**
+- **Error handling:**
   - Functions return `{:ok, result}`, `:ok` (for simple success), or `{:error, reason}`.
   - `reason` is a structured tuple (e.g., `{:sqlite_failure, code, extended_code, message}`, `{:operation_cancelled}`).
 

--- a/lib/xqlite/pragma.ex
+++ b/lib/xqlite/pragma.ex
@@ -331,7 +331,6 @@ defmodule Xqlite.Pragma do
   end
 
   defp process_list_result(key, rows) do
-    # This logic can be refined later if needed, but for now it's a direct move.
     case key do
       :collation_list ->
         Enum.map(rows, fn [seq, name] -> %{seq: seq, name: name} end)

--- a/lib/xqlite/xqlitenif.ex
+++ b/lib/xqlite/xqlitenif.ex
@@ -42,15 +42,12 @@ defmodule XqliteNIF do
   SQLite will attempt to create it. URI filenames are supported
   (e.g., "file:my_db.sqlite?mode=ro").
 
-  `opts` is a keyword list for future options (currently unused at the NIF level).
-
   Returns `{:ok, conn_resource}` on success, where `conn_resource` is an
   opaque reference to the database connection. Returns `{:error, reason}`
   on failure, e.g., if the path is invalid or permissions are insufficient.
   """
-  @spec open(path :: String.t(), opts :: keyword()) ::
-          {:ok, Xqlite.conn()} | {:error, Xqlite.error()}
-  def open(_path, _opts \\ []), do: err()
+  @spec open(path :: String.t()) :: {:ok, Xqlite.conn()} | {:error, Xqlite.error()}
+  def open(_path), do: err()
 
   @doc """
   Opens a connection to an in-memory SQLite database.

--- a/lib/xqlite/xqlitenif.ex
+++ b/lib/xqlite/xqlitenif.ex
@@ -35,6 +35,8 @@ defmodule XqliteNIF do
 
   @type stream_fetch_ok_result :: %{rows: [list(term())]}
 
+  @default_memory_database ":memory:"
+
   @doc """
   Opens a connection to an SQLite database file.
 
@@ -52,16 +54,21 @@ defmodule XqliteNIF do
   @doc """
   Opens a connection to an in-memory SQLite database.
 
-  `uri` is typically `":memory:"` for a private, temporary in-memory database.
-  It can also be a URI filename like `"file:memdb1?mode=memory&cache=shared"`
-  to create a named in-memory database that can be shared across connections
-  in the same process.
+    @doc \"""
+  Opens a connection to an in-memory SQLite database.
+
+  Can be called with no arguments to open a private, temporary in-memory
+  database (`":memory:"`). It can also be called with a URI filename like
+  `"file:memdb1?mode=memory&cache=shared"` to create a named in-memory
+  database that can be shared across connections in the same process.
 
   Returns `{:ok, conn_resource}` on success or `{:error, reason}` on failure.
   """
-  @spec open_in_memory(uri :: String.t()) ::
-          {:ok, Xqlite.conn()} | {:error, Xqlite.error()}
-  def open_in_memory(_path \\ ":memory:"), do: err()
+  @spec open_in_memory() :: {:ok, Xqlite.conn()} | {:error, Xqlite.error()}
+  def open_in_memory(), do: open_in_memory(@default_memory_database)
+
+  @spec open_in_memory(uri :: String.t()) :: {:ok, Xqlite.conn()} | {:error, Xqlite.error()}
+  def open_in_memory(_uri), do: err()
 
   @doc """
   Opens a connection to a private, temporary on-disk SQLite database.

--- a/mix.exs
+++ b/mix.exs
@@ -12,7 +12,6 @@ defmodule Xqlite.MixProject do
       name: @name,
       start_permanent: Mix.env() == :prod,
       docs: docs(),
-      aliases: aliases(),
       deps: deps(),
       compilers: Mix.compilers(),
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -28,8 +27,7 @@ defmodule Xqlite.MixProject do
         "coveralls.detail": :test,
         "coveralls.post": :test,
         "coveralls.html": :test,
-        "coveralls.circle": :test,
-        t: :test
+        "coveralls.circle": :test
       ],
 
       # type checking
@@ -48,12 +46,9 @@ defmodule Xqlite.MixProject do
 
   defp deps do
     [
-      # dependencies that are always included.
-
       {:rustler, "~> 0.37.1", runtime: false},
 
-      # dev / test dependencies.
-
+      # dev / test.
       {:benchee, "~> 1.0", only: :dev, runtime: false},
       {:dialyxir, "~> 1.4", only: :dev, runtime: false},
       {:ex_doc, "~> 0.20", only: :dev, runtime: false},
@@ -68,12 +63,10 @@ defmodule Xqlite.MixProject do
       source_url: "https://github.com/dimitarvp/xqlite",
       source_ref: "v#{@version}",
       extras: ["README.md", "LICENSE.md"],
-      # Group modules for better navigation in the sidebar.
       groups_for_modules: [
         "High-Level API": [
           Xqlite,
           Xqlite.Pragma,
-          # It will be hidden but good to group
           Xqlite.StreamResourceCallbacks
         ],
         "Schema Structs": [
@@ -117,14 +110,6 @@ defmodule Xqlite.MixProject do
       plt_file: {:no_warn, "priv/plts/core.plt"},
       plt_add_apps: [:mix]
       # flags: ["-Wunmatched_returns", ...],
-    ]
-  end
-
-  defp aliases do
-    [
-      c: "compile",
-      f: ["format", "cmd cargo fmt --manifest-path native/xqlitenif/Cargo.toml"],
-      t: "test"
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,12 +2,11 @@ defmodule Xqlite.MixProject do
   use Mix.Project
 
   @name "Xqlite"
-  @version "0.2.9"
 
   def project do
     [
       app: :xqlite,
-      version: @version,
+      version: "0.2.9",
       elixir: "~> 1.15",
       name: @name,
       start_permanent: Mix.env() == :prod,
@@ -61,7 +60,7 @@ defmodule Xqlite.MixProject do
       main: "readme",
       name: "Xqlite",
       source_url: "https://github.com/dimitarvp/xqlite",
-      source_ref: "v#{@version}",
+      source_ref: "v0.2.9",
       extras: ["README.md", "LICENSE.md"],
       groups_for_modules: [
         "High-Level API": [

--- a/native/xqlitenif/src/cancel.rs
+++ b/native/xqlitenif/src/cancel.rs
@@ -58,8 +58,6 @@ impl<'conn> ProgressHandlerGuard<'conn> {
 impl Drop for ProgressHandlerGuard<'_> {
     fn drop(&mut self) {
         if self.is_registered {
-            // Unregister the handler using the correct signature
-            // Pass 0 for num_ops (ignored when handler is None), and None for handler.
             self.conn.progress_handler(0, None::<fn() -> bool>);
         }
     }

--- a/test/support/test_util.ex
+++ b/test/support/test_util.ex
@@ -10,8 +10,8 @@ defmodule Xqlite.TestUtil do
 
   @tag_to_mfa_map Map.new(@connection_openers, fn {tag, _prefix, mfa} -> {tag, mfa} end)
 
-  defp open_and_configure(opener_mfa) do
-    with {:ok, conn} <- apply(elem(opener_mfa, 0), elem(opener_mfa, 1), elem(opener_mfa, 2)) do
+  defp open_and_configure({mod, fun, args}) do
+    with {:ok, conn} <- apply(mod, fun, args) do
       :ok = NIF.set_pragma(conn, "journal_mode", "WAL")
       :ok = NIF.set_pragma(conn, "journal_size_limit", 0)
       :ok = NIF.set_pragma(conn, "cache_size", -1000)


### PR DESCRIPTION
This PR aims to nail every single potential neglected piece of code or comment in preparation for a first official release. This will of course not be achieved but it'll be a last honest effort to do so. Can't fix everything! Let it at least be in a good shape.

### Tasks

- [x] Remove overzealous / low-effort / superfluous comments
- [x] Inline project version so tools like `versioce` or `git_ops` can work with the `mix.exs` file
- [x] Remove various bits and pieces from `mix.exs`
- [x] Fix Rust CI/CD by adding `rustfmt` and `clippy`
- [x] Replace annoying Title Case in `README.md` with proper sentence case
- [x] Make a default argument for `open_in_memory` explicit (just making sure we are not tripping up Rustler)
- [x] Remove an unused argument (keyword list) to `open`; was never used