### PR TITLE
chore: fix needing to purge GitHub Actions cache before push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,17 @@ jobs:
           elixir-version: ${{ env.DEFAULT_ELIXIR }}
           otp-version: ${{ env.DEFAULT_OTP }}
 
+      - name: Restore dependencies cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+            priv/native
+          key: ${{ runner.os }}-dialyzer-elixir-${{ steps.beam.outputs.elixir-version }}-otp-${{ steps.beam.outputs.otp-version }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-dialyzer-elixir-${{ steps.beam.outputs.elixir-version }}-otp-${{ steps.beam.outputs.otp-version }}-mix-
+
       - name: Restore PLT cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Fixes #22. But not only.

### Changes

- [x] `actions/checkout@v4` upgraded to `actions/checkout@v6`
- [x] Make the default Erlang and Elixir env vars for ease of future editing
- [x] Make cache keys specific for Erlang and Elixir versions in the runners matrix down to the patch levels
- [x] Add build caching step for the Dialyzer type-checking step
- [x] Remove a dedicated Rust caching step
- [x] Parameterize cache keys with Erlang & Elixir versions identified by other steps; I don't want to have to hardcode these deep inside the file
- [x] Add `priv/native` to the step that restores Elixir dependencies cache. 🎉 This has fixed the original issue where I had to manually purge GHA cache before pushing. Of course that was my oversight but at the time I was sick of GHA (well, I still am). But, it's fixed now.
- [x] A few small changes to make things more explicit