### PR TITLE
chore: introduce Rust caching in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   format_and_lint:
-    name: Format & lint checks
+    name: Format & lints
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -45,7 +45,7 @@ jobs:
         run: mix format --check-formatted
 
   dialyzer:
-    name: Dialyzer type checks
+    name: Type checks
     runs-on: ubuntu-latest
     needs: format_and_lint
     steps:
@@ -89,7 +89,7 @@ jobs:
         run: mix dialyzer --format short
 
   test:
-    name: Run all tests
+    name: Tests
     runs-on: ${{ matrix.os }}
     needs: format_and_lint
     strategy:


### PR DESCRIPTION
Fixes #24.

### Changes

- [x] Introduce Rust caching for faster `clippy` checks
- [x] Shorten GHA step names (so they don't get cut in GitHub's UI)