### PR TITLE
Use `rustler_precompiled`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Xqlite
 env:
   DEFAULT_ELIXIR: "1.19"
   DEFAULT_OTP: "28"
+  XQLITE_BUILD: "true"
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Build precompiled NIFs
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build_release:
+    name: NIF ${{ matrix.nif }} - ${{ matrix.job.target }} (${{ matrix.job.os }})
+    runs-on: ${{ matrix.job.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        nif: ["2.17"]
+        job:
+          - { target: aarch64-apple-darwin,       os: macos-14 }
+          - { target: x86_64-apple-darwin,        os: macos-13 }
+          - { target: aarch64-unknown-linux-gnu,   os: ubuntu-22.04, use-cross: true }
+          - { target: aarch64-unknown-linux-musl,  os: ubuntu-22.04, use-cross: true }
+          - { target: riscv64gc-unknown-linux-gnu,  os: ubuntu-22.04, use-cross: true }
+          - { target: x86_64-unknown-linux-gnu,    os: ubuntu-22.04 }
+          - { target: x86_64-unknown-linux-musl,   os: ubuntu-22.04, use-cross: true }
+          - { target: x86_64-pc-windows-msvc,      os: windows-latest }
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract project version
+        shell: bash
+        run: |
+          VERSION=$(sed -n 's/^.*version: "\(.*\)".*/\1/p' mix.exs | head -n1)
+          echo "PROJECT_VERSION=${VERSION}" >> $GITHUB_ENV
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.job.target }}
+
+      - name: Build the project
+        id: build-crate
+        uses: philss/rustler-precompiled-action@v1.1.4
+        with:
+          project-name: xqlitenif
+          project-version: ${{ env.PROJECT_VERSION }}
+          target: ${{ matrix.job.target }}
+          nif-version: ${{ matrix.nif }}
+          use-cross: ${{ matrix.job.use-cross || false }}
+          project-dir: "native/xqlitenif"
+
+      - name: Artifact upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.build-crate.outputs.file-name }}
+          path: ${{ steps.build-crate.outputs.file-path }}
+
+      - name: Publish to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.build-crate.outputs.file-path }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ xqlite-*.tar
 
 # Dialyzer artifacts.
 /priv/plts
+
+# Precompiled NIF checksums (generated per release, included in hex package).
+checksum-*.exs

--- a/lib/xqlite/xqlitenif.ex
+++ b/lib/xqlite/xqlitenif.ex
@@ -31,7 +31,25 @@ defmodule XqliteNIF do
   SQLite control or for building such abstractions.
   """
 
-  use Rustler, otp_app: :xqlite, crate: :xqlitenif, mode: :release
+  @version Mix.Project.config()[:version]
+
+  use RustlerPrecompiled,
+    otp_app: :xqlite,
+    crate: "xqlitenif",
+    base_url: "https://github.com/dimitarvp/xqlite/releases/download/v#{@version}",
+    version: @version,
+    force_build: System.get_env("XQLITE_BUILD") in ["1", "true"],
+    targets: ~w(
+      aarch64-apple-darwin
+      aarch64-unknown-linux-gnu
+      aarch64-unknown-linux-musl
+      riscv64gc-unknown-linux-gnu
+      x86_64-apple-darwin
+      x86_64-pc-windows-msvc
+      x86_64-unknown-linux-gnu
+      x86_64-unknown-linux-musl
+    ),
+    nif_versions: ["2.17"]
 
   @type stream_fetch_ok_result :: %{rows: [list(term())]}
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Xqlite.MixProject do
   def project do
     [
       app: :xqlite,
-      version: "0.3.1",
+      version: "0.4.0-dev",
       elixir: "~> 1.15",
       name: @name,
       start_permanent: Mix.env() == :prod,
@@ -51,7 +51,8 @@ defmodule Xqlite.MixProject do
 
   defp deps do
     [
-      {:rustler, "~> 0.37.1", runtime: false},
+      {:rustler, "~> 0.37.1", optional: true},
+      {:rustler_precompiled, "~> 0.8"},
 
       # dev / test.
       {:benchee, "~> 1.0", only: :dev, runtime: false},
@@ -105,14 +106,15 @@ defmodule Xqlite.MixProject do
       },
       files: [
         "lib",
+        "native/xqlitenif/.cargo",
         "native/xqlitenif/src",
         "native/xqlitenif/Cargo.toml",
         "native/xqlitenif/Cargo.lock",
+        "checksum-*.exs",
         ".formatter.exs",
         "mix.exs",
         "README.md",
         "LICENSE.md"
-        # "checksum-*.exs"
       ]
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "benchee": {:hex, :benchee, "1.5.0", "4d812c31d54b0ec0167e91278e7de3f596324a78a096fd3d0bea68bb0c513b10", [:mix], [{:deep_merge, "~> 1.0", [hex: :deep_merge, repo: "hexpm", optional: false]}, {:statistex, "~> 1.1", [hex: :statistex, repo: "hexpm", optional: false]}, {:table, "~> 0.1.0", [hex: :table, repo: "hexpm", optional: true]}], "hexpm", "5b075393aea81b8ae74eadd1c28b1d87e8a63696c649d8293db7c4df3eb67535"},
+  "castore": {:hex, :castore, "1.0.17", "4f9770d2d45fbd91dcf6bd404cf64e7e58fed04fadda0923dc32acca0badffa2", [:mix], [], "hexpm", "12d24b9d80b910dd3953e165636d68f147a31db945d2dcb9365e441f8b5351e5"},
   "deep_merge": {:hex, :deep_merge, "1.0.0", "b4aa1a0d1acac393bdf38b2291af38cb1d4a52806cf7a4906f718e1feb5ee961", [:mix], [], "hexpm", "ce708e5f094b9cd4e8f2be4f00d2f4250c4095be93f8cd6d018c753894885430"},
   "dialyxir": {:hex, :dialyxir, "1.4.7", "dda948fcee52962e4b6c5b4b16b2d8fa7d50d8645bbae8b8685c3f9ecb7f5f4d", [:mix], [{:erlex, ">= 0.2.8", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "b34527202e6eb8cee198efec110996c25c5898f43a4094df157f8d28f27d9efe"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.44", "f20830dd6b5c77afe2b063777ddbbff09f9759396500cdbe7523efd58d7a339c", [:mix], [], "hexpm", "4778ac752b4701a5599215f7030989c989ffdc4f6df457c5f36938cc2d2a2750"},
@@ -12,5 +13,6 @@
   "makeup_erlang": {:hex, :makeup_erlang, "1.0.2", "03e1804074b3aa64d5fad7aa64601ed0fb395337b982d9bcf04029d68d51b6a7", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "af33ff7ef368d5893e4a267933e7744e46ce3cf1f61e2dccf53a111ed3aa3727"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.4.2", "8efba0122db06df95bfaa78f791344a89352ba04baedd3849593bfce4d0dc1c6", [:mix], [], "hexpm", "4b21398942dda052b403bbe1da991ccd03a053668d147d53fb8c4e0efe09c973"},
   "rustler": {:hex, :rustler, "0.37.1", "721434020c7f6f8e1cdc57f44f75c490435b01de96384f8ccb96043f12e8a7e0", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "24547e9b8640cf00e6a2071acb710f3e12ce0346692e45098d84d45cdb54fd79"},
+  "rustler_precompiled": {:hex, :rustler_precompiled, "0.8.4", "700a878312acfac79fb6c572bb8b57f5aae05fe1cf70d34b5974850bbf2c05bf", [:mix], [{:castore, "~> 0.1 or ~> 1.0", [hex: :castore, repo: "hexpm", optional: false]}, {:rustler, "~> 0.23", [hex: :rustler, repo: "hexpm", optional: true]}], "hexpm", "3b33d99b540b15f142ba47944f7a163a25069f6d608783c321029bc1ffb09514"},
   "statistex": {:hex, :statistex, "1.1.0", "7fec1eb2f580a0d2c1a05ed27396a084ab064a40cfc84246dbfb0c72a5c761e5", [:mix], [], "hexpm", "f5950ea26ad43246ba2cce54324ac394a4e7408fdcf98b8e230f503a0cba9cf5"},
 }

--- a/native/xqlitenif/.cargo/config.toml
+++ b/native/xqlitenif/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.'cfg(target_os = "macos")']
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]
+
+[target.aarch64-unknown-linux-musl]
+rustflags = ["-C", "target-feature=-crt-static"]


### PR DESCRIPTION
Closes #30.

- [x] `cargo` cross-compilation config for macOS dynamic linking and musl targets
- [x] `rustler` made optional, `rustler_precompiled` added as required dep
- [x] NIF module switched from `use Rustler` to `use RustlerPrecompiled` with 8 targets and NIF 2.17
- [x] checksum glob added to hex package files and `.gitignore`
- [x] version bumped to `0.4.0-dev`
- [x] tag-triggered release workflow (`release.yml`) for precompiled NIF builds
- [x] CI force-builds from source via `XQLITE_BUILD=true`

### targets

- `aarch64-apple-darwin`
- `aarch64-unknown-linux-gnu`
- `aarch64-unknown-linux-musl`
- `riscv64gc-unknown-linux-gnu`
- `x86_64-apple-darwin`
- `x86_64-pc-windows-msvc`
- `x86_64-unknown-linux-gnu`
- `x86_64-unknown-linux-musl`
